### PR TITLE
Update TOP_EU_US_Ads_Trackers_HOST

### DIFF
--- a/TOP_EU_US_Ads_Trackers_HOST
+++ b/TOP_EU_US_Ads_Trackers_HOST
@@ -1525,7 +1525,6 @@
 0.0.0.0 digitalhub-h.de
 0.0.0.0 digitalriver.com
 0.0.0.0 digitalwindow.com
-0.0.0.0 digitec.ch
 0.0.0.0 digitize.ie
 0.0.0.0 digitru.st
 0.0.0.0 dinclinx.com


### PR DESCRIPTION
digitec.ch is an online-shop in switzerland.
Please remove this from the list.